### PR TITLE
fix(remove-admin-only-text) removed text

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-110-add-event-typo.635",
+   "version": "0.1.0-issue-AB-94-remove-admin-only-text.637",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-110-add-event-typo.635",
+   "version": "0.1.0-issue-AB-94-remove-admin-only-text.637",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-details/admin-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-details/admin-details.component.html
@@ -1,5 +1,5 @@
 <!-- Form Dialog Title -->
-<h2 mat-dialog-title>Toevoegen/bewerken (enkel admin)</h2>
+<h2 mat-dialog-title>Toevoegen/bewerken</h2>
 
 <!-- Form Dialog Content -->
 <mat-dialog-content>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/careusers/care-user-details/care-user-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/careusers/care-user-details/care-user-details.component.html
@@ -1,5 +1,5 @@
 <!-- Form Dialog Title -->
-<h2 mat-dialog-title>Toevoegen/bewerken (enkel admin)</h2>
+<h2 mat-dialog-title>Toevoegen/bewerken</h2>
 
 <!-- Form Dialog Content -->
 <mat-dialog-content>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-details/legalguardian-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-details/legalguardian-details.component.html
@@ -1,5 +1,5 @@
 <!-- Form Dialog Title -->
-<h2 mat-dialog-title>Toevoegen/bewerken (enkel admin)</h2>
+<h2 mat-dialog-title>Toevoegen/bewerken</h2>
 
 <!-- Form Dialog Content -->
 <mat-dialog-content>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-details/singerevent-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-details/singerevent-details.component.html
@@ -1,5 +1,5 @@
 <!-- Form Dialog Title -->
-<h2 mat-dialog-title>Toevoegen/bewerken (enkel admin)</h2>
+<h2 mat-dialog-title>Toevoegen/bewerken</h2>
 
 <!-- Form Dialog Content -->
 <mat-dialog-content>


### PR DESCRIPTION
Removed the unnecesarry "admin only" text from the Form titles.

[AB#94](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/94)