### PR TITLE
Bugfix/ab#84 rename adress to streetnumber

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.687",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.688",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.704",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.710",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-theme-AB-74-singer-background.666",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.687",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.688",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.689",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.687",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.688",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.704",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.710",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-theme-AB-74-singer-background.666",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.687",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.688",
+   "version": "0.1.0-issue-AB-84-rename-adress-to-streetnumber.689",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-details/legalguardian-details.component.ts
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-details/legalguardian-details.component.ts
@@ -43,7 +43,7 @@ export class LegalguardianDetailsComponent implements OnInit {
    // Form placeholders
    firstNameFieldPlaceholder = 'Voornaam';
    lastNameFieldPlaceholder = 'Familienaam';
-   addressFieldPlaceholder = 'Adres';
+   addressFieldPlaceholder = 'Straat en huisnummer (+ busnr)';
    postalCodeFieldPlaceholder = 'Postcode';
    cityFieldPlaceholder = 'Gemeente';
    countryFieldPlaceholder = 'Land';


### PR DESCRIPTION
As requested I renamed the adress field placeholder text from "adress" to "Straat en huisnummer (+ busnr)".
Change has already been reviewed and approved by Kevin.

[AB#84](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/84)