### PR TITLE
fix: Generated event slots until & including end date

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-dev.787",
+   "version": "0.1.0-issue-AB-118-eventslot-generation-fix.839",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-dev.787",
+   "version": "0.1.0-issue-AB-118-eventslot-generation-fix.839",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/Models/EventSlot.cs
+++ b/Singer.API/Models/EventSlot.cs
@@ -17,7 +17,7 @@ namespace Singer.Models
 
       public IList<EventRegistration> Registrations { get; set; }
 
-      public static IEnumerable<EventSlot> GenerateEventSlotsUntil(DateTime start, DateTime end, DateTime until, TimeUnit interval)
+      public static IEnumerable<EventSlot> GenerateEventSlotsUntilIncluding(DateTime start, DateTime end, DateTime until, TimeUnit interval)
       {
          Func<DateTime, DateTime> increase;
          switch (interval)
@@ -40,7 +40,7 @@ namespace Singer.Models
 
          var duration = end - start;
          until = until.SetTime(start);
-         for (var i = start; i < until; i = increase(i))
+         for (var i = start; i <= until; i = increase(i))
             yield return new EventSlot { StartDateTime = i, EndDateTime = i + duration, };
       }
 

--- a/Singer.API/Services/EventService.cs
+++ b/Singer.API/Services/EventService.cs
@@ -95,7 +95,7 @@ namespace Singer.Services
          switch (dto.RepeatSettings?.RepeatType)
          {
             case RepeatType.OnDate:
-               return EventSlot.GenerateEventSlotsUntil(
+               return EventSlot.GenerateEventSlotsUntilIncluding(
                   dto.StartDateTime,
                   dto.EndDateTime,
                   dto.RepeatSettings.StopRepeatDate,

--- a/Tests/ModelTests/EventSlotTests.cs
+++ b/Tests/ModelTests/EventSlotTests.cs
@@ -19,7 +19,7 @@ namespace Tests.ModelTests
          var start = DateTime.Parse("2019-01-01T14:00:00+00:00");
          var end = DateTime.Parse("2019-01-01T16:00:00+00:00");
          var until = DateTime.Parse("2019-01-16");
-         var slots = EventSlot.GenerateEventSlotsUntil(start, end, until, TimeUnit.Day).ToList();
+         var slots = EventSlot.GenerateEventSlotsUntilIncluding(start, end, until, TimeUnit.Day).ToList();
 
          slots.Count
             .Should()
@@ -44,7 +44,7 @@ namespace Tests.ModelTests
          var start = DateTime.Parse("2018-12-31T00:00:00+00:00");
          var end = DateTime.Parse("2019-01-01T00:00:00+00:00");
          var until = DateTime.Parse("2019-01-15");
-         var slots = EventSlot.GenerateEventSlotsUntil(start, end, until, TimeUnit.Day).ToList();
+         var slots = EventSlot.GenerateEventSlotsUntilIncluding(start, end, until, TimeUnit.Day).ToList();
 
          slots.Count
             .Should()
@@ -69,7 +69,7 @@ namespace Tests.ModelTests
          var start = DateTime.Parse("2018-12-31T20:00:00+00:00");
          var end = DateTime.Parse("2019-01-01T06:00:00+00:00");
          var until = DateTime.Parse("2019-01-15");
-         var slots = EventSlot.GenerateEventSlotsUntil(start, end, until, TimeUnit.Day).ToList();
+         var slots = EventSlot.GenerateEventSlotsUntilIncluding(start, end, until, TimeUnit.Day).ToList();
 
          slots.Count
             .Should()
@@ -94,7 +94,7 @@ namespace Tests.ModelTests
          var start = DateTime.Parse("2019-01-15T14:00:00+00:00");
          var end = DateTime.Parse("2019-01-15T16:00:00+00:00");
          var until = DateTime.Parse("2019-12-16");
-         var slots = EventSlot.GenerateEventSlotsUntil(start, end, until, TimeUnit.Month).ToList();
+         var slots = EventSlot.GenerateEventSlotsUntilIncluding(start, end, until, TimeUnit.Month).ToList();
 
          slots.Count
             .Should()


### PR DESCRIPTION
The function has been renamed and logic rewritten to generate event
slots until and including the end date

Closes [AB#118](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/118)