### PR TITLE
fix: Prevent wrong button being default form action

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-107-dashboard-event-duration-wrong.843",
+   "version": "0.1.0-dev.850",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-107-dashboard-event-duration-wrong.843",
+   "version": "0.1.0-dev.850",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-details/admin-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-details/admin-details.component.html
@@ -53,9 +53,14 @@
             [placeholder]="emailFieldPlaceholder"
             formControlName="emailFieldControl"
          />
-         <mat-error *ngIf="formControlGroup.controls.emailFieldControl.invalid">{{
-            getEmailFieldErrorMessage(formControlGroup.controls.emailFieldControl)
-         }}</mat-error>
+         <mat-error
+            *ngIf="formControlGroup.controls.emailFieldControl.invalid"
+            >{{
+               getEmailFieldErrorMessage(
+                  formControlGroup.controls.emailFieldControl
+               )
+            }}</mat-error
+         >
       </mat-form-field>
 
       <!-- Email Field -->
@@ -72,6 +77,7 @@
             (click)="closeForm()"
             title="Formulier sluiten"
             aria-label="Formulier sluiten"
+            type="button"
          >
             Sluiten
          </button>
@@ -102,4 +108,3 @@
       </mat-dialog-actions>
    </form>
 </mat-dialog-content>
-

--- a/Singer.API/ClientApp/src/app/modules/admin/components/careusers/care-user-details/care-user-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/careusers/care-user-details/care-user-details.component.html
@@ -327,6 +327,7 @@
             (click)="closeForm()"
             title="Formulier sluiten"
             aria-label="Formulier sluiten"
+            type="button"
          >
             Sluiten
          </button>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-details/legalguardian-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-details/legalguardian-details.component.html
@@ -200,6 +200,7 @@
             (click)="closeForm()"
             title="Formulier sluiten"
             aria-label="Formulier sluiten"
+            type="button"
          >
             Sluiten
          </button>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-details/singerevent-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-details/singerevent-details.component.html
@@ -489,6 +489,7 @@
             (click)="closeForm()"
             title="Formulier sluiten"
             aria-label="Formulier sluiten"
+            type="button"
          >
             Sluiten
          </button>

--- a/Singer.API/ClientApp/src/app/modules/core/components/user-card/user-card.component.html
+++ b/Singer.API/ClientApp/src/app/modules/core/components/user-card/user-card.component.html
@@ -16,7 +16,7 @@
       <div *ngIf="user.birthDay">Geboortedatum: {{ user.birthDay | date }}</div>
    </mat-card-content>
    <mat-card-actions>
-      <button mat-stroked-button color="" (click)="deleteUser()">
+      <button mat-stroked-button color="" (click)="deleteUser()" type="button">
          Verwijderen
       </button>
    </mat-card-actions>


### PR DESCRIPTION
By default the first standard button element inside a form element, will
be that form's submit button, and thus will be clicked when e.g.
pressing ENTER somewhere in the form.
I now added type=button attributes to all buttons which should not
behave like this.

Closes [AB#112](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/112)