### PR TITLE
fix(Dashboard): Improved event cards layout on dashboard

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-dev.850",
+   "version": "0.1.0-issue-AB-112-event-cards-spacing.852",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-dev.850",
+   "version": "0.1.0-issue-AB-112-event-cards-spacing.852",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/dashboard/components/event-card/event-card.component.css
+++ b/Singer.API/ClientApp/src/app/modules/dashboard/components/event-card/event-card.component.css
@@ -1,15 +1,22 @@
-mat-card-content p{
-   max-height: 150px;
+mat-card-content p {
+   max-height: 50px;
    text-overflow: ellipsis;
-   overflow: hidden;
+   overflow: auto;
 }
-.event-subtitle{
+.event-subtitle {
    display: flex;
    justify-content: space-between;
 }
-.date-indicator{
+.date-indicator {
    display: flex;
    align-items: center;
    font-size: 12px;
    min-width: 100px;
+}
+
+.agegroup-chips {
+   max-height: 50px;
+   overflow-y: auto;
+   overflow-x: hidden;
+   min-height: 40px;
 }

--- a/Singer.API/ClientApp/src/app/modules/dashboard/components/event-card/event-card.component.html
+++ b/Singer.API/ClientApp/src/app/modules/dashboard/components/event-card/event-card.component.html
@@ -2,7 +2,10 @@
    <mat-card-title>{{ event.title }}</mat-card-title>
    <mat-card-subtitle>
       <div class="event-subtitle">
-         <app-agegroup-chips [agegroups]="event.ageGroups"></app-agegroup-chips>
+         <app-agegroup-chips
+            [agegroups]="event.ageGroups"
+            class="agegroup-chips"
+         ></app-agegroup-chips>
 
          <div class="date-indicator" [matTooltip]="getDurationMessage(event)">
             <mat-icon>access_time</mat-icon

--- a/Singer.API/ClientApp/src/app/modules/dashboard/components/event-list/event-list.component.css
+++ b/Singer.API/ClientApp/src/app/modules/dashboard/components/event-list/event-list.component.css
@@ -1,8 +1,8 @@
-.event-card{
-  height: calc(100% - 60px);
+.event-card {
+   width: 100%;
 }
 
-mat-card{
+mat-card {
    margin: 8px;
    padding: 0px;
 }

--- a/Singer.API/ClientApp/src/app/modules/dashboard/components/event-list/event-list.component.html
+++ b/Singer.API/ClientApp/src/app/modules/dashboard/components/event-list/event-list.component.html
@@ -1,24 +1,20 @@
 <mat-card>
    <app-event-search
       [availableLocations]="availableLocations"
-      (searchEvent)="onSearchEvent($event)">
+      (searchEvent)="onSearchEvent($event)"
+   >
    </app-event-search>
 </mat-card>
 <mat-grid-list
    [cols]="breakpoint"
-   rowHeight="400px"
+   rowHeight="250px"
    gutterSize="20px"
-   (window:resize)="onResize($event)">
-   <mat-grid-tile
-      *ngFor="let event of events">
-      <app-event-card
-         [event]="event"
-         class="event-card">
-      </app-event-card>
+   (window:resize)="onResize($event)"
+>
+   <mat-grid-tile *ngFor="let event of events">
+      <app-event-card [event]="event" class="event-card"> </app-event-card>
    </mat-grid-tile>
-   <p
-      *ngIf="events.length === 0"
-      class="noEventsFoundText">
+   <p *ngIf="events.length === 0" class="noEventsFoundText">
       Geen evenementen gevonden voor deze dagen
    </p>
 </mat-grid-list>


### PR DESCRIPTION
While this probably could be improved further, this at least gets rid of
the excessive white space between the cards:

Widescreen view:
![image](https://user-images.githubusercontent.com/3620147/69014770-2771d900-098e-11ea-8e14-0e818cc4bc8e.png)

Smaller size view:
![image](https://user-images.githubusercontent.com/3620147/69014779-322c6e00-098e-11ea-927e-f9f0c0fc4874.png)

Closes [AB#112](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/112)