### PR TITLE
bugfix/AB#69-99-103-105: Fix min/max swap in StringLength attribute s…

### DIFF
--- a/Singer.API/DTOs/EventDTO.cs
+++ b/Singer.API/DTOs/EventDTO.cs
@@ -18,8 +18,8 @@ namespace Singer.DTOs
          ErrorMessageResourceName = nameof(ErrorMessages.FieldIsRequired),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [StringLength(
-         maximumLength: ValidationValues.MinEventTitleLength,
-         MinimumLength = ValidationValues.MaxEventTitleLength,
+         maximumLength: ValidationValues.MaxEventTitleLength,
+         MinimumLength = ValidationValues.MinEventTitleLength,
          ErrorMessageResourceName = nameof(ErrorMessages.FieldLengthMustBeBetween),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [Display(
@@ -165,8 +165,8 @@ namespace Singer.DTOs
         ErrorMessageResourceName = nameof(ErrorMessages.FieldIsRequired),
         ErrorMessageResourceType = typeof(ErrorMessages))]
       [StringLength(
-        maximumLength: ValidationValues.MinEventTitleLength,
-        MinimumLength = ValidationValues.MaxEventTitleLength,
+        maximumLength: ValidationValues.MaxEventTitleLength,
+        MinimumLength = ValidationValues.MinEventTitleLength,
         ErrorMessageResourceName = nameof(ErrorMessages.FieldLengthMustBeBetween),
         ErrorMessageResourceType = typeof(ErrorMessages))]
       [Display(
@@ -306,8 +306,8 @@ namespace Singer.DTOs
         ErrorMessageResourceName = nameof(ErrorMessages.FieldIsRequired),
         ErrorMessageResourceType = typeof(ErrorMessages))]
       [StringLength(
-        maximumLength: ValidationValues.MinEventTitleLength,
-        MinimumLength = ValidationValues.MaxEventTitleLength,
+        maximumLength: ValidationValues.MaxEventTitleLength,
+        MinimumLength = ValidationValues.MinEventTitleLength,
         ErrorMessageResourceName = nameof(ErrorMessages.FieldLengthMustBeBetween),
         ErrorMessageResourceType = typeof(ErrorMessages))]
       [Display(

--- a/Singer.API/DTOs/EventLocationDTO.cs
+++ b/Singer.API/DTOs/EventLocationDTO.cs
@@ -19,8 +19,8 @@ namespace Singer.DTOs
          ErrorMessageResourceName = nameof(ErrorMessages.FieldIsRequired),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [StringLength(
-         maximumLength: ValidationValues.MinNameLength,
-         MinimumLength = ValidationValues.MaxNameLength,
+         maximumLength: ValidationValues.MaxNameLength,
+         MinimumLength = ValidationValues.MinNameLength,
          ErrorMessageResourceName = nameof(ErrorMessages.FieldLengthMustBeBetween),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [Display(
@@ -91,8 +91,8 @@ namespace Singer.DTOs
          ErrorMessageResourceName = nameof(ErrorMessages.FieldIsRequired),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [StringLength(
-         maximumLength: ValidationValues.MinNameLength,
-         MinimumLength = ValidationValues.MaxNameLength,
+         maximumLength: ValidationValues.MaxNameLength,
+         MinimumLength = ValidationValues.MinNameLength,
          ErrorMessageResourceName = nameof(ErrorMessages.FieldLengthMustBeBetween),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [Display(
@@ -163,8 +163,8 @@ namespace Singer.DTOs
          ErrorMessageResourceName = nameof(ErrorMessages.FieldIsRequired),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [StringLength(
-         maximumLength: ValidationValues.MinNameLength,
-         MinimumLength = ValidationValues.MaxNameLength,
+         maximumLength: ValidationValues.MaxNameLength,
+         MinimumLength = ValidationValues.MinNameLength,
          ErrorMessageResourceName = nameof(ErrorMessages.FieldLengthMustBeBetween),
          ErrorMessageResourceType = typeof(ErrorMessages))]
       [Display(


### PR DESCRIPTION
Fix min/max swap in StringLength attribute server

[AB#69](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/69)
[AB#99](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/99)
[AB#103](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/103)
[AB#105](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/105)