### PR TITLE
bugfix(event-table-width) fixed datetime column widths

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-69-99-103-105-data-validation.954",
+   "version": "0.1.0-issue-AB-128-event-table-width.957",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-69-99-103-105-data-validation.954",
+   "version": "0.1.0-issue-AB-128-event-table-width.957",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-overview/singerevent-overview.component.css
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-overview/singerevent-overview.component.css
@@ -91,10 +91,12 @@ tr.selectable:active {
 
 .mat-column-startDateTime {
    padding: 10px;
+   min-width: 90px;
 }
 
 .mat-column-endDateTime {
    padding: 10px;
+   min-width: 90px;
 }
 
 .mat-column-hasDayCareBefore {


### PR DESCRIPTION
Fixed event table width issue with Start and Endtime columns.
These columns were to narrow and cropping their dates.

[AB#57](https://dev.azure.com/berendwouters/0d4dcc20-a52e-4b6e-90d1-33c5d5079f23/_workitems/edit/57)

Before:
![afbeelding](https://user-images.githubusercontent.com/41837971/69351334-6e581b00-0c7b-11ea-8f05-330993a85dd9.png)


After:
![afbeelding](https://user-images.githubusercontent.com/41837971/69351197-305af700-0c7b-11ea-8900-04b81d71afc7.png)
