### PR TITLE
feat(better-icons) updated user table icons

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-69-99-103-105-data-validation.954",
+   "version": "0.1.0-issue-theme-better-icons.957",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-69-99-103-105-data-validation.954",
+   "version": "0.1.0-issue-theme-better-icons.957",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-list/admin-list.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-list/admin-list.component.html
@@ -48,7 +48,7 @@
                title="Zorggebruiker toevoegen"
                aria-label="Toevoegen knop"
             >
-               <mat-icon>add_box</mat-icon>
+               <mat-icon>person_add</mat-icon>
             </button>
             <!-- <label class="tableButton">Toevoegen</label> -->
          </td>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/careusers/overview/overview.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/careusers/overview/overview.component.html
@@ -146,7 +146,7 @@
                title="Zorggebruiker toevoegen"
                aria-label="Toevoegen knop"
             >
-               <mat-icon>add_box</mat-icon>
+               <mat-icon>person_add</mat-icon>
             </button>
          </td>
       </ng-container>

--- a/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-overview/legalguardian-overview.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/legalguardians/legalguardian-overview/legalguardian-overview.component.html
@@ -59,7 +59,7 @@
                title="Voogd toevoegen"
                aria-label="Toevoegen knop"
             >
-               <mat-icon>add_box</mat-icon>
+               <mat-icon>person_add</mat-icon>
             </button>
             <!-- <label class="tableButton">Toevoegen</label> -->
          </td>


### PR DESCRIPTION
Update the icons in the user tables to the Mat-icon: person_add to give some variation, improve intent and make it less boring.

After:
![afbeelding](https://user-images.githubusercontent.com/41837971/69355238-c003a400-0c81-11ea-8134-06afd608db1f.png)
