### PR TITLE
Bugfix/timepicker type mismatch

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-69-99-103-105-data-validation.954",
+   "version": "0.1.0-issue-timepicker-type-mismatch.959",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-69-99-103-105-data-validation.954",
+   "version": "0.1.0-issue-timepicker-type-mismatch.959",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-details/singerevent-details.component.html
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/singerevents/singerevent-details/singerevent-details.component.html
@@ -390,7 +390,6 @@
          <mat-form-field>
             <input
                matInput
-               [min]="today"
                [ngxTimepicker]="dailyStartTimePicker"
                [format]="24"
                [placeholder]="dailyStartTimePlaceholder"


### PR DESCRIPTION
removed unnecesarry input binding that was serving the wrong input type,
causing the timepicker to break.