### PR TITLE
fix adds dummy emailservice when no config available

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-dev.1089",
+   "version": "0.1.0-issue-no-email-service.1090",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-65-delete-event.1077",
+   "version": "0.1.0-dev.1089",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-dev.1089",
+   "version": "0.1.0-issue-no-email-service.1090",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-AB-65-delete-event.1077",
+   "version": "0.1.0-dev.1089",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/Services/EmailService.cs
+++ b/Singer.API/Services/EmailService.cs
@@ -9,6 +9,19 @@ using Singer.Services.Interfaces;
 
 namespace Singer.Services
 {
+   public class NoActualEmailService<T> : IEmailService<T>
+      where T : IUserDTO
+   {
+      public Task SendAccountDetailsAsync(T user, string resetPasswordLink)
+      {
+         return Task.CompletedTask;
+      }
+
+      public Task SendPasswordResetLink(T user, string resetPasswordLink)
+      {
+         return Task.CompletedTask;
+      }
+   }
    public class EmailService<TUserDTO> : IEmailService<TUserDTO>
    where TUserDTO : IUserDTO
    {

--- a/Singer.API/Startup.cs
+++ b/Singer.API/Startup.cs
@@ -185,7 +185,8 @@ namespace Singer
 
 
          var configurationSection = Configuration.GetSection("EmailOptions");
-         if (configurationSection.GetChildren().Any(x => !string.IsNullOrWhiteSpace(x.Value)))
+         var hasValidEmailOptions = configurationSection.GetChildren().All(x => !string.IsNullOrWhiteSpace(x.Value));
+         if (hasValidEmailOptions)
          {
             services.Configure<EmailOptions>(configurationSection);
             services.AddScoped(typeof(IEmailService<LegalGuardianUserDTO>),

--- a/Singer.API/Startup.cs
+++ b/Singer.API/Startup.cs
@@ -28,6 +28,7 @@ using Singer.Services.Interfaces;
 using NSwag.Generation.Processors.Security;
 using NSwag;
 using System.Net;
+using Namotion.Reflection;
 using Singer.Controllers;
 using Singer.DTOs.Users;
 
@@ -180,15 +181,31 @@ namespace Singer
             .AddScoped<IDateValidator, DateValidator>();
          services.Configure<PasswordOptions>(Configuration.GetSection("PasswordOptions"));
          services.AddScoped<IUserProfileService, UserProfileService>();
-         services.Configure<EmailOptions>(Configuration.GetSection("EmailOptions"));
          services.Configure<ApplicationConfig>(Configuration.GetSection("Application"));
-         services.AddScoped(typeof(IEmailService<LegalGuardianUserDTO>),
-            typeof(EmailService<LegalGuardianUserDTO>));
-         services.AddScoped(typeof(IEmailService<AdminUserDTO>),
-            typeof(EmailService<AdminUserDTO>));
-         services.AddScoped(typeof(IEmailService<UserDTO>),
-            typeof(EmailService<UserDTO>));
-            services.AddApplicationInsightsTelemetry();
+
+
+         var configurationSection = Configuration.GetSection("EmailOptions");
+         if (configurationSection.GetChildren().Any(x => !string.IsNullOrWhiteSpace(x.Value)))
+         {
+            services.Configure<EmailOptions>(configurationSection);
+            services.AddScoped(typeof(IEmailService<LegalGuardianUserDTO>),
+               typeof(EmailService<LegalGuardianUserDTO>));
+            services.AddScoped(typeof(IEmailService<AdminUserDTO>),
+               typeof(EmailService<AdminUserDTO>));
+            services.AddScoped(typeof(IEmailService<UserDTO>),
+               typeof(EmailService<UserDTO>));
+
+         }
+         else
+         {
+            services.AddScoped(typeof(IEmailService<LegalGuardianUserDTO>),
+               typeof(NoActualEmailService<LegalGuardianUserDTO>));
+            services.AddScoped(typeof(IEmailService<AdminUserDTO>),
+               typeof(NoActualEmailService<AdminUserDTO>));
+            services.AddScoped(typeof(IEmailService<UserDTO>),
+               typeof(NoActualEmailService<UserDTO>));
+         }
+         services.AddApplicationInsightsTelemetry();
 
       }
 


### PR DESCRIPTION
When no `EmailOptions` have been set in the `appsettings.json`, use a dummy implementation.