### PR TITLE
fix(UserService): Corrected check for existing users

### DIFF
--- a/Singer.API/ClientApp/package-lock.json
+++ b/Singer.API/ClientApp/package-lock.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-locale-number-formatting.1219",
+   "version": "0.1.0-dev.1226",
    "lockfileVersion": 1,
    "requires": true,
    "dependencies": {

--- a/Singer.API/ClientApp/package.json
+++ b/Singer.API/ClientApp/package.json
@@ -1,6 +1,6 @@
 {
    "name": "Singer",
-   "version": "0.1.0-issue-locale-number-formatting.1219",
+   "version": "0.1.0-dev.1226",
    "scripts": {
       "ng": "ng",
       "start": "ng serve",

--- a/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-list/admin-list.component.ts
+++ b/Singer.API/ClientApp/src/app/modules/admin/components/admin-users/admin-list/admin-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
-import { MatPaginator, MatSort, MatDialog } from '@angular/material';
+import { MatPaginator, MatSort, MatDialog, MatSnackBar } from '@angular/material';
 import { AdminDatasource } from '../../../services/admin.datasource';
 import { AdminUserService } from '../../../services/admin-user.service';
 import { fromEvent, merge } from 'rxjs';
@@ -40,7 +40,8 @@ export class AdminListComponent implements OnInit, AfterViewInit {
       public dialog: MatDialog,
       private adminUserService: AdminUserService,
       private authService: AuthService,
-      private _loadingService: LoadingService
+      private _loadingService: LoadingService,
+      private _snackBar: MatSnackBar
    ) {}
 
    ngOnInit() {
@@ -63,21 +64,49 @@ export class AdminListComponent implements OnInit, AfterViewInit {
       });
 
       dialogRef.componentInstance.submitEvent.subscribe((result: AdminUser) => {
-         // Update the Careuser
-         this.adminUserService.update(result).subscribe(() => {
-            // Reload Careusers
-            this.loadAdmins();
-         });
+         this.adminUserService.update(result).subscribe(
+            () => {
+               this._snackBar.open(`Gebruiker ${result.firstName} ${result.lastName} werd aangepast.`, 'OK', {
+                  duration: 2000,
+               });
+               this.loadAdmins();
+            },
+            err => {
+               this.handleApiError(err);
+            }
+         );
       });
    }
    addAdmin() {
       const dialogRef = this.dialog.open(AdminDetailsComponent);
 
       dialogRef.componentInstance.submitEvent.subscribe((result: AdminUser) => {
-         this.adminUserService.create(result).subscribe(() => {
-            this.loadAdmins();
-         });
+         this.adminUserService.create(result).subscribe(
+            () => {
+               this._snackBar.open(`Gebruiker ${result.firstName} ${result.lastName} werd toegevoegd.`, 'OK', {
+                  duration: 2000,
+               });
+               this.loadAdmins();
+            },
+            err => {
+               this.handleApiError(err);
+            }
+         );
       });
+   }
+
+   handleApiError(err: any) {
+      if (typeof err === 'string') {
+         this._snackBar.open(`⚠ ${err}`, 'OK');
+      } else if (typeof err === 'object' && err !== null) {
+         let messages = [];
+         for (var k in err) {
+            messages.push(err[k]);
+         }
+         this._snackBar.open(`⚠ Er zijn fouten opgetreden bij het opslaan:\n${messages.join('\n')}`, 'OK', {
+            panelClass: 'multi-line-snackbar',
+         });
+      }
    }
 
    changePassword(row: AdminUser) {

--- a/Singer.API/Services/UserService.cs
+++ b/Singer.API/Services/UserService.cs
@@ -53,7 +53,7 @@ namespace Singer.Services
          }
          else
          {
-            var existingEmail = await Queryable.SingleOrDefaultAsync(x => x.User.Email == dto.Email);
+            var existingEmail = await UserManager.FindByEmailAsync(dto.Email);
 
             if (existingEmail != null)
                throw new BadInputException("The email address must be unique to each user.", ErrorMessages.DuplicateEmail);
@@ -68,12 +68,13 @@ namespace Singer.Services
          };
 
          var userCreationResult = await UserManager.CreateAsync(baseUser);
-         var passwordResetToken = await UserManager.GeneratePasswordResetTokenAsync(baseUser);
+
          if (!userCreationResult.Succeeded)
          {
             Debug.WriteLine($"User can not be created. {userCreationResult.Errors.First().Code}");
             throw new InternalServerException($"User can not be created. {userCreationResult.Errors.First().Description}");
          }
+         var passwordResetToken = await UserManager.GeneratePasswordResetTokenAsync(baseUser);
 
          var createdUser = await UserManager.FindByEmailAsync(dto.Email);
          var entity = Mapper.Map<TUserEntity>(dto);


### PR DESCRIPTION
The previous check checked on the specific user type (e.g. AdminUsers),
however if a user with the same email address existed in another table
(e.g. LegalGuardianUsers) the check would not find that user and proceed
with trying to add the new admin user. This would fail with a vague
error