### PR TITLE
Update VS Code settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,8 +6,7 @@
    "recommendations": [
       "ms-dotnettools.csharp",
       "esbenp.prettier-vscode",
-      "KnisterPeter.vscode-commitizen",
-      "msjsdiag.debugger-for-chrome"
+      "KnisterPeter.vscode-commitizen"
    ],
    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
    "unwantedRecommendations": []

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+   "sdk": {
+      "allowPrerelease": false
+   }
+}


### PR DESCRIPTION
Fix voor Bug 159
Removed recommendation for deprecated JS debugging extension.
JS debugging is now built into vs Code.
Added global.json to block use of preview SDK's for dotnet.